### PR TITLE
Repeated attempts at input stream request

### DIFF
--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -1,0 +1,1 @@
+makefile.linux

--- a/Linux/env64.env
+++ b/Linux/env64.env
@@ -1,0 +1,8 @@
+
+EBDIR=$( readlink -f -- $(dirname $BASH_SOURCE) )/
+
+# export CPATH=$CPATH:/usr/include/libxml2/
+export TARGET_PLATFORM=x86_64
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${EBDIR}lib64/
+export EBCLIENT=${EBDIR}ebclient
+


### PR DESCRIPTION
Instead of giving up immediately when an input stream request fails, we
now attempt a number of times after a brief pause. Both parameters are
hard-coded for simplicity. Debug messages track the number of attempts.